### PR TITLE
[typo-ci]: configure excluded words for typo ci

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -1,0 +1,8 @@
+---
+dictionaries:
+  - en
+excluded_words:
+  - natds
+  - natura
+  - naturacosmeticos
+spellcheck_filenames: true


### PR DESCRIPTION
# Description

This excludes the words `natds`, `natura` and `naturacosmeticos` from the typo ci checks

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
