### PR TITLE
[DSY-837] feat(button): add support to button sizes

### DIFF
--- a/src/common/HelperComponents/StoryContainer.tsx
+++ b/src/common/HelperComponents/StoryContainer.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components/native';
+import { ContainerRow, ContainerWithTheme, TextWithTheme } from './ThemeHelper.styles';
+
+export const StoryContainer = ({ children, title }) => (
+  <Container>
+      <Title>{title}</Title>
+      <ContainerRow>
+        {children}
+      </ContainerRow>
+  </Container>
+);
+
+const Container = styled(ContainerWithTheme)`
+  max-width: 600px;
+  padding: 24px;
+`;
+
+const Title = styled(TextWithTheme)`
+  margin-bottom: 8px;
+`;

--- a/src/components/Button/Button.device.tsx
+++ b/src/components/Button/Button.device.tsx
@@ -1,17 +1,17 @@
 import { storiesOf } from '@storybook/react-native';
 import {
-  all,
-  contained,
-  disabled,
-  interactive,
-  outlined,
-  text,
+  All,
+  Default,
+  Variants,
+  Interactive,
+  Size,
+  Disabled,
 } from './Button.stories';
 
 storiesOf('Button', module)
-  .add('all', all)
-  .add('contained', contained)
-  .add('outlined', outlined)
-  .add('text', text)
-  .add('disabled', disabled)
-  .add('interactive', interactive);
+  .add('all', All)
+  .add('default', Default)
+  .add('variants', Variants)
+  .add('size', Size)
+  .add('disabled', Disabled)
+  .add('interactive', Interactive);

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,9 +1,8 @@
-
 import React from 'react';
 import { View } from 'react-native';
 import { boolean, select, text as textKnob } from '@storybook/addon-knobs';
-import { ContainerRow, ContainerWithTheme } from '../../common/HelperComponents/ThemeHelper.styles';
-import { Button, ButtonTypes } from './Button';
+import { StoryContainer } from '../../common/HelperComponents/StoryContainer';
+import { Button, ButtonTypes, ButtonSizes } from './Button';
 
 export default {
   component: Button,
@@ -13,74 +12,66 @@ export default {
   title: 'Components|Button',
 };
 
-const onPress = () => { };
+const onPress = () => {};
 
 const buttonTypes = {
   contained: 'contained',
   outlined: 'outlined',
   text: 'text',
 };
+const buttonSizes = {
+  large: 'large',
+  medium: 'medium',
+  small: 'small',
+};
 
-export const all = () => (
-  <View style={{ maxWidth: 600, padding: 30 }}>
-    <ContainerRow style={{ marginBottom: 30 }}>
-      <Button onPress={onPress} text="default" />
-      <Button onPress={onPress} text="default" type="outlined" />
-      <Button onPress={onPress} text="default" type="text" />
-    </ContainerRow >
-    <ContainerRow style={{ marginBottom: 30 }}>
-      <Button disabled onPress={onPress} text="default" />
-      <Button disabled onPress={onPress} text="default" type="outlined" />
-      <Button disabled onPress={onPress} text="default" type="text" />
-    </ContainerRow >
-    <ContainerWithTheme style={{ height: 200, justifyContent: 'space-between', marginBottom: 30 }} >
-      <Button onPress={onPress} text="default" />
-      <Button onPress={onPress} text="default" type="outlined" />
-      <Button onPress={onPress} text="default" type="text" />
-    </ContainerWithTheme >
-    <ContainerWithTheme style={{ height: 200, justifyContent: 'space-between', marginBottom: 30 }} >
-      <Button disabled onPress={onPress} text="default" />
-      <Button disabled onPress={onPress} text="default" type="outlined" />
-      <Button disabled onPress={onPress} text="default" type="text" />
-    </ContainerWithTheme >
+export const Default = () => (
+  <StoryContainer title="Default">
+    <Button onPress={onPress} text="default" />
+  </StoryContainer>
+);
+
+export const Variants = () => (
+  <StoryContainer title="Variants">
+    <Button type="contained" onPress={onPress} text="default" />
+    <Button type="outlined" onPress={onPress} text="default" />
+    <Button type="text" onPress={onPress} text="default" />
+  </StoryContainer>
+);
+
+export const Size = () => (
+  <StoryContainer title="Sizes">
+    <Button onPress={onPress} text="default" size="large" />
+    <Button onPress={onPress} text="default" size="medium" />
+    <Button onPress={onPress} text="default" size="small" />
+  </StoryContainer>
+);
+
+export const Disabled = () => (
+  <StoryContainer title="Disabled">
+    <Button disabled type="contained" onPress={onPress} text="default" />
+    <Button disabled type="outlined" onPress={onPress} text="default" />
+    <Button disabled type="text" onPress={onPress} text="default" />
+  </StoryContainer>
+);
+
+export const All = () => (
+  <View>
+    <Default />
+    <Variants />
+    <Size />
+    <Disabled />
   </View>
 );
 
-export const disabled = () => (
-  <View style={{ maxWidth: 600, padding: 30 }}>
-    <ContainerRow style={{ marginBottom: 30 }}>
-      <Button disabled onPress={onPress} text="default" />
-      <Button disabled onPress={onPress} text="default" type="outlined" />
-      <Button disabled onPress={onPress} text="default" type="text" />
-    </ContainerRow >
-  </View>
-);
-
-export const contained = () => (
-  <ContainerRow style={{ padding: 30 }} >
-    <Button onPress={onPress} text="default" type="contained" />
-  </ContainerRow>
-);
-
-export const outlined = () => (
-  <ContainerRow style={{ padding: 30 }}>
-    <Button onPress={onPress} text="default" type="outlined" />
-  </ContainerRow>
-);
-
-export const text = () => (
-  <ContainerRow style={{ padding: 30 }}>
-    <Button onPress={onPress} text="default" type="text" />
-  </ContainerRow>
-);
-
-export const interactive = () => (
-  <ContainerRow style={{ padding: 30 }} >
+export const Interactive = () => (
+  <StoryContainer title="Interactive">
     <Button
       onPress={onPress}
       text={textKnob('Text', 'default')}
       type={select('Types', buttonTypes, 'contained') as ButtonTypes}
+      size={select('Size', buttonSizes, 'medium') as ButtonSizes}
       disabled={boolean('Disabled', false)}
     />
-  </ContainerRow>
+  </StoryContainer>
 );

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -11,15 +11,18 @@ jest.mock('react-native/Libraries/Components/Touchable/TouchableHighlight',
 
 jest.mock('../../common/themeSelectors', () => (
   {
-    getButtonPropsBySize: () => ({ background: '#AEAEAE' }),
+    getButtonPropsBySize: () => ({ background: '#EEEEEE' }),
     getColorHighEmphasis: () => '#FAF3E3',
     getColorLowEmphasis: () => '#FEEEEF',
     getColorMediumEmphasis: () => '#FAFAEA',
     getColorOnPrimary: () => '#F4F4',
     getColorPrimary: () => '#FFFFFF',
     getColorPrimaryLight: () => '#BABABA',
+    getMediumSize: () => 66,
     getOpacity10: () => 0.8,
     getRadiusBySize: () => 42,
+    getSemiSize: () => 68,
+    getSemixSize: () => 67,
     getShadowBySize: () => ({ shadowColor: '#AEAEAE' }),
   }));
 
@@ -39,6 +42,7 @@ describe('Button component', () => {
     const { queryByTestId } = renderButton(render, defaultProps);
 
     expect(queryByTestId('button')?.props).toHaveProperty('type', 'contained');
+    expect(queryByTestId('button')?.props).toHaveProperty('size', 'medium');
     expect(queryByTestId('button')?.props).toHaveProperty('disabled', false);
     expect(queryByTestId('button')).toHaveTextContent('LABEL BUTTON');
   });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import React from 'react';
 import styled, { withTheme } from 'styled-components/native';
 import { NativeSyntheticEvent, NativeTouchEvent } from 'react-native';
@@ -16,6 +17,7 @@ import {
 } from '../../common/themeSelectors';
 
 export type ButtonTypes = 'contained' | 'outlined' | 'text'
+export type ButtonSizes = 'large' | 'medium' | 'small'
 
 export interface ButtonProps {
   /**
@@ -55,12 +57,10 @@ export interface ButtonProps {
   * Optional ID for testing
   */
   testID?: string,
-}
-
-interface ButtonBase {
-  type: ButtonTypes
-  disabled: boolean
-  theme: Theme
+  /**
+   * Button sizes `large` | `medium` | `small`
+   */
+  size?: ButtonSizes,
 }
 
 const isContained = (type: ButtonTypes) => type === 'contained';
@@ -88,36 +88,48 @@ const getButtonTextColor = (theme: Theme, type: ButtonTypes, disabled: boolean) 
   return disabled ? color.disabled : color.active;
 };
 
-const ButtonBase = styled.TouchableHighlight<ButtonBase>(({ type, theme, disabled = false }) => ({
-  borderRadius: getRadiusBySize(theme, 'medium'),
-  ...getButtonStyles(theme, type, disabled),
-  ...getButtonPropsBySize(theme, 'medium'),
-}));
-
-const Text = styled.Text<ButtonBase>`
-  color: ${({ type, theme, disabled }) => getButtonTextColor(theme, type, disabled)};
-  font-size: 14px;
-  align-self: center;
-  letter-spacing: 1px;
-`;
-
 const getShadowByType = (type: ButtonTypes, disabled: boolean, theme: Theme) => (
   isContained(type) && !disabled
     ? getShadowBySize(theme, '2')
     : {}
 );
 
+const ButtonBase = styled.TouchableHighlight<{
+  type: ButtonTypes
+  disabled: boolean
+  theme: Theme
+  size: ButtonSizes
+}>(({
+  type, theme, disabled = false, size,
+}) => ({
+  ...getButtonPropsBySize(theme, size),
+  ...getButtonStyles(theme, type, disabled),
+  borderRadius: getRadiusBySize(theme, 'medium'),
+}));
+
+const Text = styled.Text<{
+  type: ButtonTypes
+  disabled: boolean
+  theme: Theme
+}>(({ type, theme, disabled = false }) => ({
+  alignSelf: 'center',
+  color: getButtonTextColor(theme, type, disabled),
+  fontSize: 14,
+  letterSpacing: 1,
+}));
+
 const ButtonComponent = ({
-  onPress, theme, text, type = 'contained', disabled = false, testID = 'button', accessibilityLabel, accessibilityHint,
+  onPress, theme, text, type = 'contained', disabled = false, testID = 'button', accessibilityLabel, accessibilityHint, size = 'medium',
 }: ButtonProps) => (
   <ButtonBase
-    testID={testID}
-    type={type}
-    onPress={disabled ? () => {} : onPress}
-    style={getShadowByType(type, disabled, theme)}
-    underlayColor={getColorPrimaryLight(theme)}
     activeOpacity={getOpacity10(theme)}
     disabled={disabled}
+    onPress={disabled ? () => {} : onPress}
+    size={size}
+    style={getShadowByType(type, disabled, theme)}
+    testID={testID}
+    type={type}
+    underlayColor={getColorPrimaryLight(theme)}
   >
     <Text
       style={{ fontWeight: 'bold' }}

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -5,10 +5,11 @@ exports[`Button component Disabled variants should render disabled button compon
   activeOpacity={0.8}
   disabled={false}
   onPress={[Function]}
+  size="medium"
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 42,
       },
       Object {
@@ -48,10 +49,11 @@ exports[`Button component Disabled variants should render disabled button compon
   activeOpacity={0.8}
   disabled={true}
   onPress={[Function]}
+  size="medium"
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
+        "backgroundColor": "#EEEEEE",
         "borderColor": "#FAFAEA",
         "borderRadius": 42,
         "borderWidth": 1,
@@ -91,10 +93,11 @@ exports[`Button component Disabled variants should render disabled button compon
   activeOpacity={0.8}
   disabled={true}
   onPress={[Function]}
+  size="medium"
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
+        "backgroundColor": "#EEEEEE",
         "borderRadius": 42,
       },
       Object {},
@@ -132,10 +135,11 @@ exports[`Button component Variants should render button component contained 1`] 
   activeOpacity={0.8}
   disabled={false}
   onPress={[Function]}
+  size="medium"
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 42,
       },
       Object {
@@ -175,10 +179,11 @@ exports[`Button component Variants should render button component outlined 1`] =
   activeOpacity={0.8}
   disabled={false}
   onPress={[Function]}
+  size="medium"
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
+        "backgroundColor": "#EEEEEE",
         "borderColor": "#FFFFFF",
         "borderRadius": 42,
         "borderWidth": 1,
@@ -218,10 +223,11 @@ exports[`Button component Variants should render button component text 1`] = `
   activeOpacity={0.8}
   disabled={true}
   onPress={[Function]}
+  size="medium"
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
+        "backgroundColor": "#EEEEEE",
         "borderRadius": 42,
       },
       Object {},


### PR DESCRIPTION
# Description

This adds the `size` attribute in the `Button` component as described at: [Component | Button [React Native]
](https://natura.atlassian.net/browse/DSY-837) and [Button_UIDOC_NATDS](https://xd.adobe.com/view/ec5f3181-e1bc-4dd3-b2fb-dfbf8cf512b1-b90c/screen/8dc70f32-be8a-4928-aaac-d1f4a3322fd4/). No dependencies were added or removed.

Also, this reorganizes the `size` and `buttonSizes` tokens, that were incorrectly named.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

To see the changes included in this, you may want to run the storybook app or sample phone app and check the size section under the Button Component. I should show three buttons, representing **'large'** **'medium'**  and **'small'** sizes. Also, the `interactive` section should include a size selection option.

- [x] The buttons should be styled as the UI documentation shows
- [x] The buttons should behave the same as others when clicked

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
