### PR TITLE
[DSY-1460] feat(button) create button base that supports colors

### DIFF
--- a/src/common/themeSelectors/colors/colors.ts
+++ b/src/common/themeSelectors/colors/colors.ts
@@ -1,5 +1,36 @@
 import { Theme, checkTheme } from '..';
 
+export interface IColors {
+  primary: string;
+  onPrimary: string;
+  primaryLight: string;
+  onPrimaryLight: string;
+  primaryDark: string;
+  onPrimaryDark: string;
+  secondary: string;
+  onSecondary: string;
+  secondaryLight: string;
+  onSecondaryLight: string;
+  secondaryDark: string;
+  onSecondaryDark: string;
+  background: string;
+  onBackground: string;
+  surface: string;
+  onSurface: string;
+  highlight: string;
+  highEmphasis: string;
+  mediumEmphasis: string;
+  lowEmphasis: string;
+  link: string;
+  onLink: string;
+  success: string;
+  onSuccess: string;
+  warning: string;
+  onWarning: string;
+  alert: string;
+  onAlert: string;
+}
+
 const getColors = (theme: Theme) => checkTheme(theme).colorTokens;
 
 export const getColorPrimary = (theme: Theme) => getColors(theme).colorPrimary;
@@ -23,4 +54,4 @@ export const getColorSurface = (theme: Theme) => getColors(theme).colorSurface;
 
 export const getColorHighlight = (theme: Theme) => getColors(theme).colorHighlight;
 
-export const getColorByName = (theme: Theme, colorName: string) => getColors(theme)[colorName];
+export const getColorByName = (theme: Theme, colorName: string) => getColors(theme)[`color${colorName.charAt(0).toUpperCase()}${colorName.slice(1)}`];

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { View } from 'react-native';
 import { boolean, select, text as textKnob } from '@storybook/addon-knobs';
 import { ContainerRow, ContainerWithTheme } from '../../common/HelperComponents/ThemeHelper.styles';
-import { Button, ButtonTypes } from './Button';
+import { Button } from './Button';
+import { ButtonTypes } from './ButtonBase';
 
 export default {
   component: Button,

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -11,7 +11,7 @@ jest.mock('react-native/Libraries/Components/Touchable/TouchableHighlight',
 
 jest.mock('../../common/themeSelectors', () => (
   {
-    getButtonPropsBySize: () => ({ background: '#AEAEAE' }),
+    getButtonPropsBySize: () => ({ minHeight: 48 }),
     getColorHighEmphasis: () => '#FAF3E3',
     getColorLowEmphasis: () => '#FEEEEF',
     getColorMediumEmphasis: () => '#FAFAEA',

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,45 +1,8 @@
 import React from 'react';
-import styled, { withTheme } from 'styled-components/native';
 import { NativeSyntheticEvent, NativeTouchEvent } from 'react-native';
-import {
-  getColorPrimary,
-  getColorOnPrimary,
-  getColorHighEmphasis,
-  getColorMediumEmphasis,
-  getColorLowEmphasis,
-  getButtonPropsBySize,
-  getRadiusBySize,
-  getShadowBySize,
-  Theme,
-  getOpacity10,
-  getColorPrimaryLight,
-} from '../../common/themeSelectors';
-
-export type ButtonTypes = 'contained' | 'outlined' | 'text'
+import { ButtonBase, ButtonTypes } from './ButtonBase';
 
 export interface ButtonProps {
-  /**
-   * The onPress event handler
-   */
-  onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void,
-  /**
-   * The button text content
-   */
-  text: string
-  /**
-   * Button variants `contained` | `outlined` | `text`
-   */
-  type?: ButtonTypes
-  /**
-   * A disabled button is unusable and un-clickable.
-   * The disabled attribute can be set to keep a user from clicking on the button until some
-   * other condition has been met (like selecting a checkbox, etc.).
-   */
-  disabled?: boolean
-  /**
-   * The button theme
-   */
-  theme: Theme,
   /**
    * An accessibility hint helps users understand what will happen when they perform an action
    * on the accessibility element when that result is not clear from the accessibility label.
@@ -52,82 +15,46 @@ export interface ButtonProps {
    */
   accessibilityLabel?: string
   /**
+   * A disabled button is unusable and un-clickable.
+   * The disabled attribute can be set to keep a user from clicking on the button until some
+   * other condition has been met (like selecting a checkbox, etc.).
+   */
+  disabled?: boolean
+  /**
+   * The onPress event handler
+   */
+  onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void,
+  /**
   * Optional ID for testing
   */
   testID?: string,
+  /**
+   * The button text content
+   */
+  text: string
+  /**
+   * Button variants `contained` | `outlined` | `text`
+   */
+  type?: ButtonTypes
 }
 
-interface ButtonBase {
-  type: ButtonTypes
-  disabled: boolean
-  theme: Theme
-}
-
-const isContained = (type: ButtonTypes) => type === 'contained';
-
-const getButtonStyles = (theme: Theme, type: ButtonTypes, disabled: boolean) => {
-  const styles = {
-    contained: {
-      background: disabled ? getColorLowEmphasis(theme) : getColorPrimary(theme),
-    },
-    outlined: {
-      borderColor: disabled ? getColorMediumEmphasis(theme) : getColorPrimary(theme),
-      borderWidth: 1,
-    },
-  };
-
-  return styles[type];
-};
-
-const getButtonTextColor = (theme: Theme, type: ButtonTypes, disabled: boolean) => {
-  const color = {
-    active: isContained(type) ? getColorOnPrimary(theme) : getColorHighEmphasis(theme),
-    disabled: isContained(type) ? getColorHighEmphasis(theme) : getColorMediumEmphasis(theme),
-  };
-
-  return disabled ? color.disabled : color.active;
-};
-
-const ButtonBase = styled.TouchableHighlight<ButtonBase>(({ type, theme, disabled = false }) => ({
-  borderRadius: getRadiusBySize(theme, 'medium'),
-  ...getButtonStyles(theme, type, disabled),
-  ...getButtonPropsBySize(theme, 'medium'),
-}));
-
-const Text = styled.Text<ButtonBase>`
-  color: ${({ type, theme, disabled }) => getButtonTextColor(theme, type, disabled)};
-  font-size: 14px;
-  align-self: center;
-  letter-spacing: 1px;
-`;
-
-const getShadowByType = (type: ButtonTypes, disabled: boolean, theme: Theme) => (
-  isContained(type) && !disabled
-    ? getShadowBySize(theme, '2')
-    : {}
-);
-
-const ButtonComponent = ({
-  onPress, theme, text, type = 'contained', disabled = false, testID = 'button', accessibilityLabel, accessibilityHint,
+export const Button = ({
+  accessibilityHint,
+  accessibilityLabel,
+  disabled = false,
+  onPress,
+  testID = 'button',
+  text,
+  type = 'contained',
 }: ButtonProps) => (
   <ButtonBase
-    testID={testID}
-    type={type}
-    onPress={disabled ? () => {} : onPress}
-    style={getShadowByType(type, disabled, theme)}
-    underlayColor={getColorPrimaryLight(theme)}
-    activeOpacity={getOpacity10(theme)}
-    disabled={disabled}
-  >
-    <Text
-      style={{ fontWeight: 'bold' }}
-      accessibilityLabel={accessibilityLabel}
-      accessibilityHint={accessibilityHint}
-      accessibilityRole="button"
-      type={type}
-      disabled={disabled}
-    >{text.toUpperCase()}</Text>
-  </ButtonBase>
+    accessibilityHint={ accessibilityHint }
+    accessibilityLabel={ accessibilityLabel }
+    disabled={ disabled }
+    textColor='default'
+    onPress={ onPress }
+    testID={ testID }
+    text={ text }
+    type={ type }
+  />
 );
-
-export const Button = withTheme(ButtonComponent);

--- a/src/components/Button/ButtonBase.tsx
+++ b/src/components/Button/ButtonBase.tsx
@@ -1,0 +1,125 @@
+/* eslint-disable max-lines */
+import React from 'react';
+import styled, { withTheme } from 'styled-components/native';
+import { NativeSyntheticEvent, NativeTouchEvent } from 'react-native';
+import {
+  IColors,
+  Theme,
+  getButtonPropsBySize,
+  getColorHighEmphasis,
+  getColorLowEmphasis,
+  getColorMediumEmphasis,
+  getColorOnPrimary,
+  getColorPrimary,
+  getColorPrimaryLight,
+  getOpacity10,
+  getRadiusBySize,
+  getShadowBySize,
+  getColorByName,
+} from '../../common/themeSelectors';
+
+export type ButtonTypes = 'contained' | 'outlined' | 'text'
+export type TextColors = keyof IColors | 'default'
+
+export interface ButtonProps {
+  accessibilityHint?: string
+  accessibilityLabel?: string
+  disabled?: boolean
+  textColor: TextColors
+  onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void,
+  testID?: string
+  text: string
+  theme: Theme
+  type?: ButtonTypes
+}
+
+const isContained = (type: ButtonTypes) => type === 'contained';
+
+const getButtonStyles = (theme: Theme, type: ButtonTypes, disabled: boolean) => {
+  const styles = {
+    contained: {
+      background: disabled ? getColorLowEmphasis(theme) : getColorPrimary(theme),
+    },
+    outlined: {
+      borderColor: disabled ? getColorMediumEmphasis(theme) : getColorPrimary(theme),
+      borderWidth: 1,
+    },
+  };
+
+  return styles[type];
+};
+
+const getButtonTextColor = (theme: Theme, type: ButtonTypes, disabled: boolean) => {
+  const color = {
+    active: isContained(type) ? getColorOnPrimary(theme) : getColorHighEmphasis(theme),
+    disabled: isContained(type) ? getColorHighEmphasis(theme) : getColorMediumEmphasis(theme),
+  };
+
+  return disabled ? color.disabled : color.active;
+};
+
+const getShadowByType = (type: ButtonTypes, disabled: boolean, theme: Theme) => (
+  isContained(type) && !disabled
+    ? getShadowBySize(theme, '2')
+    : {}
+);
+
+const Base = styled.TouchableHighlight<{
+  type: ButtonTypes
+  disabled: boolean
+  theme: Theme
+}>(({
+  type, theme, disabled = false,
+}) => ({
+  ...getButtonPropsBySize(theme, 'medium'),
+  ...getButtonStyles(theme, type, disabled),
+  borderRadius: getRadiusBySize(theme, 'medium'),
+}));
+
+const Label = styled.Text<{
+  type: ButtonTypes
+  disabled: boolean
+  textColor: TextColors
+  theme: Theme
+}>(({
+  type, theme, disabled, textColor,
+}) => ({
+  alignSelf: 'center',
+  color: textColor === 'default' ? getButtonTextColor(theme, type, disabled) : getColorByName(theme, textColor),
+  fontSize: 14,
+  fontWeight: 'bold',
+  letterSpacing: 1,
+}));
+
+const ButtonComponent = ({
+  accessibilityHint,
+  accessibilityLabel,
+  disabled = false,
+  textColor,
+  onPress,
+  testID = 'button',
+  text,
+  theme,
+  type = 'contained',
+}: ButtonProps) => (
+  <Base
+    activeOpacity={getOpacity10(theme)}
+    disabled={disabled}
+    onPress={disabled ? () => {} : onPress}
+    style={getShadowByType(type, disabled, theme)}
+    testID={testID}
+    type={type}
+    underlayColor={getColorPrimaryLight(theme)}
+  >
+    <Label
+      accessibilityHint={accessibilityHint}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      disabled={disabled}
+      textColor={textColor}
+      type={type}
+    >{text.toUpperCase()}</Label>
+  </Base>
+);
+
+export const ButtonBase = withTheme(ButtonComponent);

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -8,8 +8,9 @@ exports[`Button component Disabled variants should render disabled button compon
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 42,
+        "minHeight": 48,
       },
       Object {
         "shadowColor": "#AEAEAE",
@@ -29,13 +30,12 @@ exports[`Button component Disabled variants should render disabled button compon
           "alignSelf": "center",
           "color": "#F4F4",
           "fontSize": 14,
-          "letterSpacing": 1,
-        },
-        Object {
           "fontWeight": "bold",
+          "letterSpacing": 1,
         },
       ]
     }
+    textColor="default"
     type="contained"
   >
     LABEL BUTTON
@@ -51,10 +51,10 @@ exports[`Button component Disabled variants should render disabled button compon
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
         "borderColor": "#FAFAEA",
         "borderRadius": 42,
         "borderWidth": 1,
+        "minHeight": 48,
       },
       Object {},
     ]
@@ -72,13 +72,12 @@ exports[`Button component Disabled variants should render disabled button compon
           "alignSelf": "center",
           "color": "#FAFAEA",
           "fontSize": 14,
-          "letterSpacing": 1,
-        },
-        Object {
           "fontWeight": "bold",
+          "letterSpacing": 1,
         },
       ]
     }
+    textColor="default"
     type="outlined"
   >
     LABEL BUTTON
@@ -94,8 +93,8 @@ exports[`Button component Disabled variants should render disabled button compon
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
         "borderRadius": 42,
+        "minHeight": 48,
       },
       Object {},
     ]
@@ -113,13 +112,12 @@ exports[`Button component Disabled variants should render disabled button compon
           "alignSelf": "center",
           "color": "#FAFAEA",
           "fontSize": 14,
-          "letterSpacing": 1,
-        },
-        Object {
           "fontWeight": "bold",
+          "letterSpacing": 1,
         },
       ]
     }
+    textColor="default"
     type="text"
   >
     LABEL BUTTON
@@ -135,8 +133,9 @@ exports[`Button component Variants should render button component contained 1`] 
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 42,
+        "minHeight": 48,
       },
       Object {
         "shadowColor": "#AEAEAE",
@@ -156,13 +155,12 @@ exports[`Button component Variants should render button component contained 1`] 
           "alignSelf": "center",
           "color": "#F4F4",
           "fontSize": 14,
-          "letterSpacing": 1,
-        },
-        Object {
           "fontWeight": "bold",
+          "letterSpacing": 1,
         },
       ]
     }
+    textColor="default"
     type="contained"
   >
     LABEL BUTTON
@@ -178,10 +176,10 @@ exports[`Button component Variants should render button component outlined 1`] =
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
         "borderColor": "#FFFFFF",
         "borderRadius": 42,
         "borderWidth": 1,
+        "minHeight": 48,
       },
       Object {},
     ]
@@ -199,13 +197,12 @@ exports[`Button component Variants should render button component outlined 1`] =
           "alignSelf": "center",
           "color": "#FAF3E3",
           "fontSize": 14,
-          "letterSpacing": 1,
-        },
-        Object {
           "fontWeight": "bold",
+          "letterSpacing": 1,
         },
       ]
     }
+    textColor="default"
     type="outlined"
   >
     LABEL BUTTON
@@ -221,8 +218,8 @@ exports[`Button component Variants should render button component text 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "#AEAEAE",
         "borderRadius": 42,
+        "minHeight": 48,
       },
       Object {},
     ]
@@ -240,13 +237,12 @@ exports[`Button component Variants should render button component text 1`] = `
           "alignSelf": "center",
           "color": "#FAFAEA",
           "fontSize": 14,
-          "letterSpacing": 1,
-        },
-        Object {
           "fontWeight": "bold",
+          "letterSpacing": 1,
         },
       ]
     }
+    textColor="default"
     type="text"
   >
     LABEL BUTTON

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -3,37 +3,9 @@ import { withTheme } from 'styled-components/native';
 import { Text } from 'react-native';
 import iconNames from '@naturacosmeticos/natds-icons/dist/natds-icons.json';
 import { ISizes } from '@naturacosmeticos/natds-styles';
-import { Theme, getColorByName } from '../../common/themeSelectors';
+import { Theme, IColors, getColorByName } from '../../common/themeSelectors';
 
-export type IconColors = 'default'
-                        | 'primary'
-                        | 'onPrimary'
-                        | 'primaryLight'
-                        | 'onPrimaryLight'
-                        | 'primaryDark'
-                        | 'onPrimaryDark'
-                        | 'secondary'
-                        | 'onSecondary'
-                        | 'secondaryLight'
-                        | 'onSecondaryLight'
-                        | 'secondaryDark'
-                        | 'onSecondaryDark'
-                        | 'background'
-                        | 'onBackground'
-                        | 'surface'
-                        | 'onSurface'
-                        | 'highlight'
-                        | 'highEmphasis'
-                        | 'mediumEmphasis'
-                        | 'lowEmphasis'
-                        | 'link'
-                        | 'onLink'
-                        | 'success'
-                        | 'onSuccess'
-                        | 'warning'
-                        | 'onWarning'
-                        | 'alert'
-                        | 'onAlert'
+export type IconColors = keyof IColors | 'default'
 export type IconSizes = keyof ISizes
 
 export interface IconProps {
@@ -76,9 +48,8 @@ const getIconSize = (theme: Theme, size: IconSizes) => theme.sizes[size];
 
 const getFontColor = (theme: Theme, color: IconColors) => {
   const colorName = color === 'default' ? 'highEmphasis' : color;
-  const colorToken = `color${colorName.charAt(0).toUpperCase()}${colorName.slice(1)}`;
 
-  return getColorByName(theme, colorToken);
+  return getColorByName(theme, colorName);
 };
 
 const IconComponent = ({


### PR DESCRIPTION
# Description

This refactor de `Button` component creating a `ButtonBase` that can receive `textColor` by props to determine the label color.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The `Buttonbase` component can now be imported inside other components and it will receive `textColor` by props and show its label accordingly. 

- [x] The `Button` component should not be affected in any way (neither in visual nor in functionality)
- [x] The `ButtonBase` component should not be usable outside of this repository

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
