### PR TITLE
[DSY-837]  feat(button): update

### DIFF
--- a/src/common/themeSelectors/sizes/sizes.test.ts
+++ b/src/common/themeSelectors/sizes/sizes.test.ts
@@ -3,13 +3,6 @@ import * as selectors from './sizes';
 
 const scenarios = [
   {
-    expectedResult: theme.buttonSizes.medium,
-    name: 'getButtonPropsBySize',
-    params: 'medium',
-    selector: selectors.getButtonPropsBySize,
-    title: 'button',
-  },
-  {
     expectedResult: theme.radius.medium,
     name: 'getRadiusBySize',
     params: 'medium',

--- a/src/common/themeSelectors/sizes/sizes.ts
+++ b/src/common/themeSelectors/sizes/sizes.ts
@@ -1,14 +1,24 @@
 import { Theme, checkTheme } from '..';
 
 interface ButtonProperties {
-  paddingTop: number;
-  paddingRight: number;
-  paddingBottom: number;
-  paddingLeft: number;
+  paddingHorizontal: number;
   minHeight: number;
 }
 
-const getButtonSizes = (theme: Theme) => checkTheme(theme).buttonSizes;
+const getButtonSizes = (theme: Theme) => ({
+  large: {
+    minHeight: theme.sizes.medium,
+    paddingHorizontal: theme.spacing.spacingSmall,
+  },
+  medium: {
+    minHeight: theme.sizes.semix,
+    paddingHorizontal: theme.spacing.spacingTiny + 4,
+  },
+  small: {
+    minHeight: theme.sizes.semi,
+    paddingHorizontal: theme.spacing.spacingTiny,
+  },
+});
 
 export type Size = 'large' | 'medium' | 'small'
 

--- a/src/components/Button/Button.device.tsx
+++ b/src/components/Button/Button.device.tsx
@@ -6,6 +6,7 @@ import {
   Interactive,
   Size,
   Disabled,
+  Display,
 } from './Button.stories';
 
 storiesOf('Button', module)
@@ -14,4 +15,5 @@ storiesOf('Button', module)
   .add('variants', Variants)
   .add('size', Size)
   .add('disabled', Disabled)
+  .add('display block', Display)
   .add('interactive', Interactive);

--- a/src/components/Button/Button.device.tsx
+++ b/src/components/Button/Button.device.tsx
@@ -2,17 +2,19 @@ import { storiesOf } from '@storybook/react-native';
 import {
   All,
   Default,
-  Variants,
-  Interactive,
-  Size,
   Disabled,
   Display,
+  Icon,
+  Interactive,
+  Size,
+  Variants,
 } from './Button.stories';
 
 storiesOf('Button', module)
   .add('all', All)
   .add('default', Default)
   .add('variants', Variants)
+  .add('icon', Icon)
   .add('size', Size)
   .add('disabled', Disabled)
   .add('display block', Display)

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -46,6 +46,13 @@ export const Variants = () => (
   </StoryContainer>
 );
 
+export const Icon = () => (
+  <StoryContainer title="Icon">
+    <Button onPress={onPress} text="default" iconPosition="left" iconName="outlined-default-mockup" />
+    <Button onPress={onPress} text="default" iconPosition="right" iconName="outlined-default-mockup" />
+  </StoryContainer>
+);
+
 export const Size = () => (
   <StoryContainer title="Sizes">
     <Button onPress={onPress} text="default" size="large" />
@@ -72,6 +79,7 @@ export const All = () => (
   <View>
     <Default />
     <Variants />
+    <Icon />
     <Size />
     <Disabled />
     <Display />

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { boolean, select, text as textKnob } from '@storybook/addon-knobs';
 import { StoryContainer } from '../../common/HelperComponents/StoryContainer';
 import { Button } from './Button';
-import { ButtonTypes, ButtonSizes } from './ButtonBase';
+import { ButtonTypes, ButtonSizes, DisplayTypes } from './ButtonBase';
 
 export default {
   component: Button,
@@ -20,10 +20,16 @@ const buttonTypes = {
   outlined: 'outlined',
   text: 'text',
 };
+
 const buttonSizes = {
   large: 'large',
   medium: 'medium',
   small: 'small',
+};
+
+const displayTypes = {
+  block: 'block',
+  inline: 'inline',
 };
 
 export const Default = () => (
@@ -56,12 +62,19 @@ export const Disabled = () => (
   </StoryContainer>
 );
 
+export const Display = () => (
+  <StoryContainer title="Display block">
+    <Button display="block" type="contained" onPress={onPress} text="default" />
+  </StoryContainer>
+);
+
 export const All = () => (
   <View>
     <Default />
     <Variants />
     <Size />
     <Disabled />
+    <Display />
   </View>
 );
 
@@ -72,6 +85,7 @@ export const Interactive = () => (
       text={textKnob('Text', 'default')}
       type={select('Types', buttonTypes, 'contained') as ButtonTypes}
       size={select('Size', buttonSizes, 'medium') as ButtonSizes}
+      display={select('Display type', displayTypes, 'inline') as DisplayTypes}
       disabled={boolean('Disabled', false)}
     />
   </StoryContainer>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -70,9 +70,14 @@ export const Disabled = () => (
 );
 
 export const Display = () => (
-  <StoryContainer title="Display block">
-    <Button display="block" type="contained" onPress={onPress} text="default" />
-  </StoryContainer>
+  <View>
+    <StoryContainer title="Display inline">
+      <Button display="inline" type="contained" onPress={onPress} text="default" />
+    </StoryContainer>
+    <StoryContainer title="Display block">
+      <Button display="block" type="contained" onPress={onPress} text="default" />
+    </StoryContainer>
+  </View>
 );
 
 export const All = () => (

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -58,6 +58,17 @@ describe('Button component', () => {
     });
   });
 
+  it('should render button with the given display type', () => {
+    const { queryByTestId } = renderButton(render, {
+      ...defaultProps,
+      display: 'block',
+    });
+
+    expect(queryByTestId('button')).toHaveStyle({
+      flexGrow: 1,
+    });
+  });
+
   it('should call the given onPress function', () => {
     const onPressMock = jest.fn();
     const { queryByTestId } = renderButton(render, {

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -44,7 +44,7 @@ describe('Button component', () => {
     expect(queryByTestId('button')?.props).toHaveProperty('type', 'contained');
     expect(queryByTestId('button')?.props).toHaveProperty('size', 'medium');
     expect(queryByTestId('button')?.props).toHaveProperty('disabled', false);
-    expect(queryByTestId('button')).toHaveTextContent('LABEL BUTTON');
+    expect(queryByTestId('button').children[0]).toHaveTextContent('LABEL BUTTON');
   });
 
   it('should render button with the given type prop', () => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable max-lines */
 import React from 'react';
 import { NativeSyntheticEvent, NativeTouchEvent } from 'react-native';
-import { ButtonBase, ButtonSizes, ButtonTypes } from './ButtonBase';
+import {
+  ButtonBase, ButtonSizes, ButtonTypes, DisplayTypes,
+} from './ButtonBase';
 
 export interface ButtonProps {
   /**
@@ -21,6 +23,11 @@ export interface ButtonProps {
    * other condition has been met (like selecting a checkbox, etc.).
    */
   disabled?: boolean
+  /**
+   * An inline button takes only the minimum amount of space for its width, while a block
+   * button takes 100% of its container width
+   */
+  display?: DisplayTypes
   /**
    * The onPress event handler
    */
@@ -47,6 +54,7 @@ export const Button = ({
   accessibilityHint,
   accessibilityLabel,
   disabled = false,
+  display = 'inline',
   onPress,
   size = 'medium',
   testID = 'button',
@@ -57,6 +65,7 @@ export const Button = ({
     accessibilityHint={ accessibilityHint }
     accessibilityLabel={ accessibilityLabel }
     disabled={ disabled }
+    display={ display }
     textColor='default'
     onPress={ onPress }
     testID={ testID }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { NativeSyntheticEvent, NativeTouchEvent } from 'react-native';
 import {
-  ButtonBase, ButtonSizes, ButtonTypes, DisplayTypes,
+  ButtonBase, ButtonSizes, ButtonTypes, DisplayTypes, IconPositions,
 } from './ButtonBase';
 
 export interface ButtonProps {
@@ -28,6 +28,14 @@ export interface ButtonProps {
    * button takes 100% of its container width
    */
   display?: DisplayTypes
+  /**
+   * The icon name
+   */
+  iconName?: string,
+  /**
+   * Icon position relative to text label `left` | `right`
+   */
+  iconPosition?: IconPositions
   /**
    * The onPress event handler
    */
@@ -55,6 +63,8 @@ export const Button = ({
   accessibilityLabel,
   disabled = false,
   display = 'inline',
+  iconName,
+  iconPosition,
   onPress,
   size = 'medium',
   testID = 'button',
@@ -66,11 +76,13 @@ export const Button = ({
     accessibilityLabel={ accessibilityLabel }
     disabled={ disabled }
     display={ display }
-    textColor='default'
+    iconName={ iconName }
+    iconPosition={ iconPosition }
     onPress={ onPress }
-    testID={ testID }
     size={ size }
+    testID={ testID }
     text={ text }
+    textColor='default'
     type={ type }
   />
 );

--- a/src/components/Button/ButtonBase.tsx
+++ b/src/components/Button/ButtonBase.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable max-lines */
 import React from 'react';
 import styled, { withTheme } from 'styled-components/native';
-import { NativeSyntheticEvent, NativeTouchEvent } from 'react-native';
+import {
+  NativeSyntheticEvent, NativeTouchEvent, Text,
+} from 'react-native';
 import {
   IColors,
   Theme,
@@ -17,10 +19,12 @@ import {
   getShadowBySize,
   getColorByName,
 } from '../../common/themeSelectors';
+import { Icon } from '../Icon';
 
 export type ButtonSizes = 'large' | 'medium' | 'small'
 export type ButtonTypes = 'contained' | 'outlined' | 'text'
 export type DisplayTypes = 'inline' | 'block'
+export type IconPositions = 'left' | 'right'
 export type TextColors = keyof IColors | 'default'
 
 export interface ButtonProps {
@@ -28,6 +32,8 @@ export interface ButtonProps {
   accessibilityLabel?: string
   disabled?: boolean
   display?: DisplayTypes
+  iconName?: string | undefined,
+  iconPosition?: IconPositions
   textColor: TextColors
   onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void,
   size: ButtonSizes
@@ -81,6 +87,7 @@ const Base = styled.TouchableHighlight<{
   ...getButtonStyles(theme, type, disabled),
   borderRadius: getRadiusBySize(theme, 'medium'),
   flexGrow: display === 'block' ? 1 : 0,
+  justifyContent: 'center',
 }));
 
 const Label = styled.Text<{
@@ -98,16 +105,28 @@ const Label = styled.Text<{
   letterSpacing: 1,
 }));
 
+const labelContent = (text: string, iconName: string | undefined, iconPosition: IconPositions) => {
+  if (iconName) {
+    return iconPosition === 'left'
+      ? <Text><Icon name={iconName} size="small" />  {text.toUpperCase()}</Text>
+      : <Text>{text.toUpperCase()}  <Icon name={iconName} size="small" /></Text>;
+  }
+
+  return text.toUpperCase();
+};
+
 const ButtonComponent = ({
   accessibilityHint,
   accessibilityLabel,
   disabled = false,
   display = 'inline',
-  textColor,
+  iconName,
+  iconPosition = 'right',
   onPress,
   size = 'medium',
   testID = 'button',
   text,
+  textColor,
   theme,
   type = 'contained',
 }: ButtonProps) => (
@@ -129,7 +148,9 @@ const ButtonComponent = ({
       disabled={disabled}
       textColor={textColor}
       type={type}
-    >{text.toUpperCase()}</Label>
+    >
+      { labelContent(text, iconName, iconPosition) }
+    </Label>
   </Base>
 );
 

--- a/src/components/Button/ButtonBase.tsx
+++ b/src/components/Button/ButtonBase.tsx
@@ -20,12 +20,14 @@ import {
 
 export type ButtonSizes = 'large' | 'medium' | 'small'
 export type ButtonTypes = 'contained' | 'outlined' | 'text'
+export type DisplayTypes = 'inline' | 'block'
 export type TextColors = keyof IColors | 'default'
 
 export interface ButtonProps {
   accessibilityHint?: string
   accessibilityLabel?: string
   disabled?: boolean
+  display?: DisplayTypes
   textColor: TextColors
   onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void,
   size: ButtonSizes
@@ -68,15 +70,17 @@ const getShadowByType = (type: ButtonTypes, disabled: boolean, theme: Theme) => 
 
 const Base = styled.TouchableHighlight<{
   disabled: boolean
+  display: DisplayTypes
   size: ButtonSizes
   theme: Theme
   type: ButtonTypes
 }>(({
-  type, theme, disabled = false, size,
+  type, theme, disabled, display, size,
 }) => ({
   ...getButtonPropsBySize(theme, size),
   ...getButtonStyles(theme, type, disabled),
   borderRadius: getRadiusBySize(theme, 'medium'),
+  flexGrow: display === 'block' ? 1 : 0,
 }));
 
 const Label = styled.Text<{
@@ -98,6 +102,7 @@ const ButtonComponent = ({
   accessibilityHint,
   accessibilityLabel,
   disabled = false,
+  display = 'inline',
   textColor,
   onPress,
   size = 'medium',
@@ -109,6 +114,7 @@ const ButtonComponent = ({
   <Base
     activeOpacity={getOpacity10(theme)}
     disabled={disabled}
+    display={display}
     onPress={disabled ? () => {} : onPress}
     size={size}
     style={getShadowByType(type, disabled, theme)}

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Button component Disabled variants should render disabled button compon
         "backgroundColor": "#FFFFFF",
         "borderRadius": 42,
         "flexGrow": 0,
+        "justifyContent": "center",
         "minHeight": 48,
       },
       Object {
@@ -60,6 +61,7 @@ exports[`Button component Disabled variants should render disabled button compon
         "borderRadius": 42,
         "borderWidth": 1,
         "flexGrow": 0,
+        "justifyContent": "center",
         "minHeight": 48,
       },
       Object {},
@@ -103,6 +105,7 @@ exports[`Button component Disabled variants should render disabled button compon
       Object {
         "borderRadius": 42,
         "flexGrow": 0,
+        "justifyContent": "center",
         "minHeight": 48,
       },
       Object {},
@@ -147,6 +150,7 @@ exports[`Button component Variants should render button component contained 1`] 
         "backgroundColor": "#FFFFFF",
         "borderRadius": 42,
         "flexGrow": 0,
+        "justifyContent": "center",
         "minHeight": 48,
       },
       Object {
@@ -194,6 +198,7 @@ exports[`Button component Variants should render button component outlined 1`] =
         "borderRadius": 42,
         "borderWidth": 1,
         "flexGrow": 0,
+        "justifyContent": "center",
         "minHeight": 48,
       },
       Object {},
@@ -237,6 +242,7 @@ exports[`Button component Variants should render button component text 1`] = `
       Object {
         "borderRadius": 42,
         "flexGrow": 0,
+        "justifyContent": "center",
         "minHeight": 48,
       },
       Object {},

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Button component Disabled variants should render disabled button compon
 <TouchableHighlight
   activeOpacity={0.8}
   disabled={false}
+  display="inline"
   onPress={[Function]}
   size="medium"
   style={
@@ -11,6 +12,7 @@ exports[`Button component Disabled variants should render disabled button compon
       Object {
         "backgroundColor": "#FFFFFF",
         "borderRadius": 42,
+        "flexGrow": 0,
         "minHeight": 48,
       },
       Object {
@@ -48,6 +50,7 @@ exports[`Button component Disabled variants should render disabled button compon
 <TouchableHighlight
   activeOpacity={0.8}
   disabled={true}
+  display="inline"
   onPress={[Function]}
   size="medium"
   style={
@@ -56,6 +59,7 @@ exports[`Button component Disabled variants should render disabled button compon
         "borderColor": "#FAFAEA",
         "borderRadius": 42,
         "borderWidth": 1,
+        "flexGrow": 0,
         "minHeight": 48,
       },
       Object {},
@@ -91,12 +95,14 @@ exports[`Button component Disabled variants should render disabled button compon
 <TouchableHighlight
   activeOpacity={0.8}
   disabled={true}
+  display="inline"
   onPress={[Function]}
   size="medium"
   style={
     Array [
       Object {
         "borderRadius": 42,
+        "flexGrow": 0,
         "minHeight": 48,
       },
       Object {},
@@ -132,6 +138,7 @@ exports[`Button component Variants should render button component contained 1`] 
 <TouchableHighlight
   activeOpacity={0.8}
   disabled={false}
+  display="inline"
   onPress={[Function]}
   size="medium"
   style={
@@ -139,6 +146,7 @@ exports[`Button component Variants should render button component contained 1`] 
       Object {
         "backgroundColor": "#FFFFFF",
         "borderRadius": 42,
+        "flexGrow": 0,
         "minHeight": 48,
       },
       Object {
@@ -176,6 +184,7 @@ exports[`Button component Variants should render button component outlined 1`] =
 <TouchableHighlight
   activeOpacity={0.8}
   disabled={false}
+  display="inline"
   onPress={[Function]}
   size="medium"
   style={
@@ -184,6 +193,7 @@ exports[`Button component Variants should render button component outlined 1`] =
         "borderColor": "#FFFFFF",
         "borderRadius": 42,
         "borderWidth": 1,
+        "flexGrow": 0,
         "minHeight": 48,
       },
       Object {},
@@ -219,12 +229,14 @@ exports[`Button component Variants should render button component text 1`] = `
 <TouchableHighlight
   activeOpacity={0.8}
   disabled={true}
+  display="inline"
   onPress={[Function]}
   size="medium"
   style={
     Array [
       Object {
         "borderRadius": 42,
+        "flexGrow": 0,
         "minHeight": 48,
       },
       Object {},


### PR DESCRIPTION
# Description

This deals with technical and functional debts of the `Button` component. It adds support to **'sizes'**, **'icons'** and **'display'** props, as described in [DSY-837](https://natura.atlassian.net/browse/DSY-837) and the [Button UI Doc](https://xd.adobe.com/view/ec5f3181-e1bc-4dd3-b2fb-dfbf8cf512b1-b90c/screen/8dc70f32-be8a-4928-aaac-d1f4a3322fd4).

This also adds a `StoryContainer` helper component, to avoid repetition and ensure consistency in the example stories, as their numbers grow.

No dependencies were added or removed for this change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

To see the changes included in this, you may want to run the storybook app or sample phone app and check the `Button` component section under.

- [x] All button examples should be styled as the UI documentation shows
- [x]  The `Icon` section should show examples for icons on the **left** and **right** sides of the button label
- [x]  The `Size` section should show examples for **large**, **medium**, and **small** buttons
- [x]  The `Display` section should show examples for **inline** and **block** display types
- [x] The interactive section should include select or checkbox options for all props added.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
