### PR TITLE
[DSY-1306] ci: publish to npm from bitrise

### DIFF
--- a/bin/release/release.sh
+++ b/bin/release/release.sh
@@ -7,6 +7,7 @@ PRE_RELEASE_NAME=$(node ./bin/release/getPreReleaseName.js)
 [[ $1 = "pre-release" ]] && PRE_RELEASE="--prerelease ${PRE_RELEASE_NAME} --skip.tag --skip.changelog" || PRE_RELEASE=""
 [[ $PRE_RELEASE = "" ]] && TAG_NAME="latest" || TAG_NAME=$PRE_RELEASE_NAME
 
+git log "$( git describe --tags --abbrev=0 )..HEAD"
 git checkout $BITRISE_GIT_BRANCH
 git log "$( git describe --tags --abbrev=0 )..HEAD"
 

--- a/bin/release/release.sh
+++ b/bin/release/release.sh
@@ -8,6 +8,7 @@ PRE_RELEASE_NAME=$(node ./bin/release/getPreReleaseName.js)
 [[ $PRE_RELEASE = "" ]] && TAG_NAME="latest" || TAG_NAME=$PRE_RELEASE_NAME
 
 git checkout $BITRISE_GIT_BRANCH
+git log "$( git describe --tags --abbrev=0 )..HEAD"
 
 if \
   { git log "$( git describe --tags --abbrev=0 )..HEAD" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -i -E '^feat|fix|perf|refactor|revert$' ; } || \

--- a/bin/release/release.sh
+++ b/bin/release/release.sh
@@ -18,12 +18,10 @@ then
   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
   npm publish --tag $TAG_NAME
 
-  if [ -z "${PRE_RELEASE}" ]; then
-    git push --follow-tags origin HEAD
+  if [ -z "${PRE_RELEASE}" ]
+  then git push --follow-tags origin HEAD
+  else git push origin HEAD
   fi
-
-  git push origin HEAD
-  git log -3
 
 else
   echo "No applicable changes since the previous tag, skipping..."

--- a/bin/release/release.sh
+++ b/bin/release/release.sh
@@ -16,13 +16,9 @@ if \
 then
   yarn bump:version $PRE_RELEASE
   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-  npm publish --tag $TAG_NAME
 
-  if [ -z "${PRE_RELEASE}" ]; then
-    git push --tags
-  fi
+  git push --follow-tags origin HEAD && npm publish
 
-  git push
 else
   echo "No applicable changes since the previous tag, skipping..."
 fi

--- a/bin/release/release.sh
+++ b/bin/release/release.sh
@@ -16,8 +16,14 @@ if \
 then
   yarn bump:version $PRE_RELEASE
   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+  npm publish --tag $TAG_NAME
 
-  git push --follow-tags origin HEAD && npm publish
+  if [ -z "${PRE_RELEASE}" ]; then
+    git push --follow-tags origin HEAD
+  fi
+
+  git push origin HEAD
+  git log -3
 
 else
   echo "No applicable changes since the previous tag, skipping..."

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "publish:pre:release": "node ./bin/release/pre-release.js",
     "publish:release": "./bin/release/release.sh",
     "publish:storybook:web": "node ./bin/netlify/deploy.js",
-    "bump:version": "standard-version",
+    "bump:version": "standard-version --releaseCommitMessageFormat 'chore(release): {{currentTag}} [ci skip]'",
     "start:clear:cache": "rm -rf /tmp/metro-* && watchman watch-del-all && yarn start:clear",
     "start:clear": "concurrently --names 'auto-import-stories,react-native' 'rnstl' 'yarn start --reset-cache'",
     "start": "concurrently --names 'auto-import-stories,react-native' 'rnstl' 'react-native start'",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "publish:pre:release": "node ./bin/release/pre-release.js",
     "publish:release": "./bin/release/release.sh",
     "publish:storybook:web": "node ./bin/netlify/deploy.js",
-    "bump:version": "standard-version  --dry-run --releaseCommitMessageFormat 'chore(release): {{currentTag}} [ci skip]'",
+    "bump:version": "standard-version --releaseCommitMessageFormat 'chore(release): {{currentTag}} [ci skip]'",
     "start:clear:cache": "rm -rf /tmp/metro-* && watchman watch-del-all && yarn start:clear",
     "start:clear": "concurrently --names 'auto-import-stories,react-native' 'rnstl' 'yarn start --reset-cache'",
     "start": "concurrently --names 'auto-import-stories,react-native' 'rnstl' 'react-native start'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naturacosmeticos/natds-rn",
-  "version": "3.1.0",
+  "version": "3.1.1-DSY-1306.0",
   "license": "ISC",
   "main": "build/lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naturacosmeticos/natds-rn",
-  "version": "3.1.1-DSY-1306.0",
+  "version": "3.1.1-DSY-1306.1",
   "license": "ISC",
   "main": "build/lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "publish:pre:release": "node ./bin/release/pre-release.js",
     "publish:release": "./bin/release/release.sh",
     "publish:storybook:web": "node ./bin/netlify/deploy.js",
-    "bump:version": "standard-version --releaseCommitMessageFormat 'chore(release): {{currentTag}} [ci skip]'",
+    "bump:version": "standard-version  --dry-run --releaseCommitMessageFormat 'chore(release): {{currentTag}} [ci skip]'",
     "start:clear:cache": "rm -rf /tmp/metro-* && watchman watch-del-all && yarn start:clear",
     "start:clear": "concurrently --names 'auto-import-stories,react-native' 'rnstl' 'yarn start --reset-cache'",
     "start": "concurrently --names 'auto-import-stories,react-native' 'rnstl' 'react-native start'",


### PR DESCRIPTION
# Description

This makes changes so our CI pipeline can trigger NPM releases and pre-releases, as described in [DSY-1306 | Adicionar publicação de releases e pré-releases na pipeline](https://natura.atlassian.net/browse/DSY-1306). No dependencies were added or removed for this change.

## Type of change


- [ ] **Bug fix**: non-breaking change which fixes an issue
- [ ] **New feature**: non-breaking change which adds functionality
- [ ] **Breaking change**: fix or feature that would cause existing functionality to not work as expected
- [x] Other: **CI changes**
> - **Build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
> - **CI changes**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
> - **Documentation**: Documentation only changes
> - **Performance**: A code change that improves performance
> - **Refactor**: A code change that neither fixes a bug nor adds a feature
> - **Code Style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
> - **Testing**: Adding missing tests or correcting existing tests

- [ ] This change requires a documentation update

# How Has This Been Tested?

This is currently being used in our [Bitrise pipeline](https://app.bitrise.io/app/2c91a0037aed90db) in a workflow triggered by any push to the `bitrise-publish` branch that publishes a pre-release to our [npm package](https://www.npmjs.com/package/@naturacosmeticos/natds-rn)

You can check out the [**Version History**](https://www.npmjs.com/package/@naturacosmeticos/natds-rn?activeTab=versions) for the releases made by the CI pipeline:
- 3.1.1-DSY-1306.1
- 3.1.1-DSY-1306.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
