### PR TITLE
fix(natds-rn):  Stories brand-dark in GayaButton

### DIFF
--- a/src/components/GayaButton/GayaButton.stories.tsx
+++ b/src/components/GayaButton/GayaButton.stories.tsx
@@ -213,11 +213,23 @@ export const BrandDark = () => (
       <GayaButton mode="dark" brand="consultoriaDeBeleza" type="ghost" onPress={onPress} text="Button" />
       <GayaButton mode="dark" brand="consultoriaDeBeleza" type="tonal" onPress={onPress} text="Button" />
     </StoryContainer>
+    <StoryContainer title="Consultoria de Beleza v2" style={{ backgroundColor: 'black', padding: 20 }}>
+      <GayaButton mode="dark" brand="consultoriaDeBeleza_v2" type="contained" onPress={onPress} text="Button" />
+      <GayaButton mode="dark" brand="consultoriaDeBeleza_v2" type="outlined" onPress={onPress} text="Button" />
+      <GayaButton mode="dark" brand="consultoriaDeBeleza_v2" type="ghost" onPress={onPress} text="Button" />
+      <GayaButton mode="dark" brand="consultoriaDeBeleza_v2" type="tonal" onPress={onPress} text="Button" />
+    </StoryContainer>
     <StoryContainer title="Força de Vendas" style={{ backgroundColor: 'black', padding: 20 }}>
       <GayaButton mode="dark" brand="forcaDeVendas" type="contained" onPress={onPress} text="Button" />
       <GayaButton mode="dark" brand="forcaDeVendas" type="outlined" onPress={onPress} text="Button" />
       <GayaButton mode="dark" brand="forcaDeVendas" type="ghost" onPress={onPress} text="Button" />
       <GayaButton mode="dark" brand="forcaDeVendas" type="tonal" onPress={onPress} text="Button" />
+    </StoryContainer>
+    <StoryContainer title="Força de Vendas V2" style={{ backgroundColor: 'black', padding: 20 }}>
+      <GayaButton mode="dark" brand="forcaDeVendas_v2" type="contained" onPress={onPress} text="Button" />
+      <GayaButton mode="dark" brand="forcaDeVendas_v2" type="outlined" onPress={onPress} text="Button" />
+      <GayaButton mode="dark" brand="forcaDeVendas_v2" type="ghost" onPress={onPress} text="Button" />
+      <GayaButton mode="dark" brand="forcaDeVendas_v2" type="tonal" onPress={onPress} text="Button" />
     </StoryContainer>
 
   </StoryWrapper>


### PR DESCRIPTION
affects: @naturacosmeticos/natds-rn
DSY-5426

# Description

Fixed Stories brand-dark in GayaButton

## Type of change

- [ ] feat: new feature for the user, not a new feature for build script
- [ ] fix: bug fix for the user, not a fix to a build script
- [x] docs: changes to the documentation
- [ ] style: formatting, missing semi colons, etc; no production code change
- [ ] refactor: refactoring production code, eg. renaming a variable
- [ ] test: adding missing tests, refactoring tests; no production code change
- [ ] chore: updating grunt tasks etc; no production code change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors;
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;
